### PR TITLE
Fixed test

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -2,7 +2,7 @@ var assert = require('assert')
 var style  = require('./style.styl')
 
 it('allows you to require stylus files', function() {
-    assert(style.indexOf('body {  background-color: #ffc0cb;}' == 0))
+    assert(style.indexOf('body {  background-color: #ffc0cb;}') == 0)
 })
 
 it('correctly escapes css string', function() {


### PR DESCRIPTION
`style.indexOf('body {  background-color: #ffc0cb;}' == 0)` is like saying `style.indexOf(false)` and returns -1, which is truthy, so no matter what value `style` has, this assertion would have passed. I adjusted the position of the end parenthesis so that it's actually checking the index of the string. :)
